### PR TITLE
fix: allow tool calls with no arguments

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -67,11 +67,7 @@ export async function runMCPServer(config: MCPServerConfig) {
   // Handle call tool request
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
     try {
-      const { name, arguments: args } = request.params;
-
-      if (!args) {
-        throw new Error('No arguments provided');
-      }
+      const { name, arguments: args = null } = request.params;
 
       // Call the handler
       const result = await config.handleRequest({ name, args });


### PR DESCRIPTION
Per the [spec](https://github.com/modelcontextprotocol/specification/blob/main/schema/2025-03-26/schema.ts#L705-L711), tool calls can send "undefined" for arguments if no arguments are required (e.g., linear_getViewer).

This change turns `undefined` into `null` which is properly handled in the argument validation by each specific tool

Before:
![image](https://github.com/user-attachments/assets/37ae64c8-1587-4ef0-a934-c7d38c5c4e3f)

![image](https://github.com/user-attachments/assets/db70c075-e258-454d-9fc0-47f831fd81f6)

After:
![image](https://github.com/user-attachments/assets/da7dc836-5a15-477b-9089-b134795080cb)
