### PR TITLE
fix: comment, now supports parent reply

### DIFF
--- a/src/services/linear-service.ts
+++ b/src/services/linear-service.ts
@@ -517,18 +517,21 @@ export class LinearService {
     }
   }
 
-  async createComment(args: { issueId: string; body: string }) {
+  async createComment(args: { issueId: string; body: string; parentId?: string }) {
     const createdComment = await this.client.createComment({
       issueId: args.issueId,
       body: args.body,
+      parentId: args.parentId,
     });
 
     if (createdComment.success && createdComment.comment) {
       const commentData = await createdComment.comment;
+      const parent = commentData.parent ? await commentData.parent : null;
       return {
         id: commentData.id,
         body: commentData.body,
         url: commentData.url,
+        parentId: parent?.id,
       };
     } else {
       throw new Error('Failed to create comment');

--- a/src/tools/definitions/issue-tools.ts
+++ b/src/tools/definitions/issue-tools.ts
@@ -367,7 +367,7 @@ export const updateIssueToolDefinition: MCPToolDefinition = {
  */
 export const createCommentToolDefinition: MCPToolDefinition = {
   name: 'linear_createComment',
-  description: 'Add a comment to an issue in Linear',
+  description: 'Add a comment to an issue in Linear (supports threaded replies)',
   input_schema: {
     type: 'object',
     properties: {
@@ -379,6 +379,10 @@ export const createCommentToolDefinition: MCPToolDefinition = {
         type: 'string',
         description: 'Text of the comment (Markdown supported)',
       },
+      parentId: {
+        type: 'string',
+        description: 'ID of the parent comment to reply to (for threaded comments)',
+      },
     },
     required: ['issueId', 'body'],
   },
@@ -388,6 +392,7 @@ export const createCommentToolDefinition: MCPToolDefinition = {
       id: { type: 'string' },
       body: { type: 'string' },
       url: { type: 'string' },
+      parentId: { type: 'string' },
     },
   },
 };

--- a/src/tools/type-guards.ts
+++ b/src/tools/type-guards.ts
@@ -187,6 +187,7 @@ export function isUpdateIssueArgs(args: unknown): args is {
 export function isCreateCommentArgs(args: unknown): args is {
   issueId: string;
   body: string;
+  parentId?: string;
 } {
   return (
     typeof args === 'object' &&
@@ -194,7 +195,8 @@ export function isCreateCommentArgs(args: unknown): args is {
     'issueId' in args &&
     typeof (args as { issueId: string }).issueId === 'string' &&
     'body' in args &&
-    typeof (args as { body: string }).body === 'string'
+    typeof (args as { body: string }).body === 'string' &&
+    (!('parentId' in args) || typeof (args as { parentId: string }).parentId === 'string')
   );
 }
 


### PR DESCRIPTION
Hello!

Linear supports replies from a parent comment, I added this ability by providing the `parentId` optional parameter.

Thanks 😊 