### PR TITLE
Add issue unlink tools for projects and cycles

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -4,7 +4,7 @@ To develop locally:
 
 ```bash
 # Clone the repository
-git clone https://github.com/tacticlaunch/mcp-linear.git
+git clone https://github.com/itz4blitz/mcp-linear.git
 cd mcp-linear
 
 # Install dependencies

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://github.com/tacticlaunch/mcp-linear/blob/main/docs/linear-app-icon.png?raw=true" alt="Linear App Icon" width="250" height="250">
+  <img src="docs/linear-app-icon.png" alt="Linear App Icon" width="250" height="250">
 </p>
 
 # MCP Linear
@@ -7,12 +7,6 @@
 A Model Context Protocol (MCP) server implementation for the Linear GraphQL API that enables AI assistants to interact with Linear project management systems.
 
 ![MCP Linear](https://img.shields.io/badge/MCP-Linear-blue)
-[![npm version](https://img.shields.io/npm/v/@tacticlaunch/mcp-linear.svg)](https://www.npmjs.com/package/@tacticlaunch/mcp-linear)
-[![smithery badge](https://smithery.ai/badge/@tacticlaunch/mcp-linear)](https://smithery.ai/server/@tacticlaunch/mcp-linear)
-
-<a href="https://glama.ai/mcp/servers/@tacticlaunch/mcp-linear">
-  <img width="380" height="200" src="https://glama.ai/mcp/servers/@tacticlaunch/mcp-linear/badge" />
-</a>
 
 ## Features
 
@@ -49,30 +43,25 @@ To use MCP Linear, you'll need a Linear API token. Here's how to get one:
 6. Give your key a name (e.g., `MCP Linear Integration`)
 7. Copy the generated API token and store it securely - you won't be able to see it again!
 
-### Installing via [Smithery](https://smithery.ai/server/@tacticlaunch/mcp-linear) (Recommended)
-
-- To install MCP Linear for Cursor:
+### Installing from This Fork
 
 ```bash
-npx -y @smithery/cli install @tacticlaunch/mcp-linear --client cursor
-```
-
-- To install MCP Linear for Claude Desktop:
-
-```bash
-npx -y @smithery/cli install @tacticlaunch/mcp-linear --client claude
+git clone https://github.com/itz4blitz/mcp-linear.git
+cd mcp-linear
+npm install
+npm run build
+npm link
 ```
 
 ### Manual Configuration
 
-Add the following to your MCP settings file:
+After running `npm link`, add the following to your MCP settings file:
 
 ```json
 {
   "mcpServers": {
     "linear": {
-      "command": "npx",
-      "args": ["-y", "@tacticlaunch/mcp-linear"],
+      "command": "mcp-linear",
       "env": {
         "LINEAR_API_TOKEN": "<YOUR_TOKEN>"
       }
@@ -97,13 +86,11 @@ Prerequisites
 - Linear API token
 
 ```bash
-# Install globally
-npm install -g @tacticlaunch/mcp-linear
-
-# Or clone and install locally
-git clone https://github.com/tacticlaunch/mcp-linear.git
+# Clone and install locally
+git clone https://github.com/itz4blitz/mcp-linear.git
 cd mcp-linear
 npm install
+npm run build
 npm link  # Makes the package available globally
 ```
 
@@ -124,15 +111,11 @@ mcp-linear
 
 ## Available Tools
 
-See [TOOLS.md](https://github.com/tacticlaunch/mcp-linear/blob/main/TOOLS.md) for a complete list of available tools and planned features.
+See [TOOLS.md](./TOOLS.md) for a complete list of available tools and planned features.
 
 ## Development
 
-See [DEVELOPMENT.md](https://github.com/tacticlaunch/mcp-linear/blob/main/DEVELOPMENT.md) for more information on how to develop locally.
-
-## Links
-
-[tacticlaunch/cursor-memory-bank](https://github.com/tacticlaunch/cursor-memory-bank) - If you are a developer seeking to enhance your workflow with Cursor, consider giving it a try.
+See [DEVELOPMENT.md](./DEVELOPMENT.md) for more information on how to develop locally.
 
 
 ## License

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -67,6 +67,7 @@ The following tools are currently implemented and available in the MCP Linear:
 | -------------------------- | ---------------------------------------- | -------------- |
 | `linear_updateProject`     | Update an existing project               | ✅ Implemented |
 | `linear_addIssueToProject` | Add an existing issue to a project       | ✅ Implemented |
+| `linear_removeIssueFromProject` | Remove an existing issue from a project | ✅ Implemented |
 | `linear_getProjectIssues`  | Get all issues associated with a project | ✅ Implemented |
 
 ### Cycle Management Tools
@@ -76,6 +77,7 @@ The following tools are currently implemented and available in the MCP Linear:
 | `linear_getCycles`       | Get a list of all cycles                  | ✅ Implemented |
 | `linear_getActiveCycle`  | Get the currently active cycle for a team | ✅ Implemented |
 | `linear_addIssueToCycle` | Add an issue to a cycle                   | ✅ Implemented |
+| `linear_removeIssueFromCycle` | Remove an issue from a cycle          | ✅ Implemented |
 
 ### Initiative Management Tools
 
@@ -109,7 +111,6 @@ The following tools are recommended for future implementation to enhance the cap
 | ------------------------------- | --------------------------------- | -------- | ---------- |
 | `linear_archiveProject`         | Archive a project                 | Medium   | 📝 Planned |
 | `linear_getProjectUpdates`      | Get updates for a project         | Medium   | 📝 Planned |
-| `linear_removeIssueFromProject` | Remove an issue from a project    | Medium   | 📝 Planned |
 | `linear_getProjectMembers`      | Get members assigned to a project | Medium   | 📝 Planned |
 | `linear_addProjectMember`       | Add a member to a project         | Medium   | 📝 Planned |
 | `linear_removeProjectMember`    | Remove a member from a project    | Medium   | 📝 Planned |
@@ -121,7 +122,6 @@ The following tools are recommended for future implementation to enhance the cap
 | `linear_getCycleById`         | Get details of a specific cycle | Medium   | 📝 Planned |
 | `linear_createCycle`          | Create a new cycle              | Medium   | 📝 Planned |
 | `linear_updateCycle`          | Update an existing cycle        | Medium   | 📝 Planned |
-| `linear_removeIssueFromCycle` | Remove an issue from a cycle    | Medium   | 📝 Planned |
 | `linear_completeCycle`        | Mark a cycle as complete        | Medium   | 📝 Planned |
 | `linear_getCycleStats`        | Get statistics for a cycle      | Medium   | 📝 Planned |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@tacticlaunch/mcp-linear",
+  "name": "@itz4blitz/mcp-linear",
   "version": "1.0.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@tacticlaunch/mcp-linear",
+      "name": "@itz4blitz/mcp-linear",
       "version": "1.0.12",
       "hasInstallScript": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,9 @@
       "linear_updateIssue",
       "linear_createComment",
       "linear_addIssueLabel",
-      "linear_removeIssueLabel"
+      "linear_removeIssueLabel",
+      "linear_removeIssueFromProject",
+      "linear_removeIssueFromCycle"
     ]
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@tacticlaunch/mcp-linear",
+  "name": "@itz4blitz/mcp-linear",
   "version": "1.0.12",
   "description": "A Model Context Protocol (MCP) server implementation for the Linear GraphQL API that enables AI assistants to interact with Linear project management systems.",
   "main": "dist/index.js",
@@ -60,7 +60,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/tacticlaunch/mcp-linear"
+    "url": "https://github.com/itz4blitz/mcp-linear"
   },
   "dependencies": {
     "@linear/sdk": "^38.0.0",

--- a/src/__tests__/linear-service.test.ts
+++ b/src/__tests__/linear-service.test.ts
@@ -116,3 +116,88 @@ describe('LinearService optional field sanitization', () => {
     });
   });
 });
+
+describe('LinearService issue unlink operations', () => {
+  it('removes an issue from a project', async () => {
+    const issue = jest
+      .fn()
+      .mockResolvedValueOnce({
+        id: 'issue-1',
+        identifier: 'ABC-123',
+        title: 'Test issue',
+        project: Promise.resolve({
+          id: 'project-1',
+          name: 'Roadmap',
+        }),
+      })
+      .mockResolvedValueOnce({
+        id: 'issue-1',
+        identifier: 'ABC-123',
+        title: 'Test issue',
+      });
+    const project = jest.fn().mockResolvedValue({
+      id: 'project-1',
+      name: 'Roadmap',
+    });
+    const updateIssue = jest.fn().mockResolvedValue({ success: true });
+    const service = new LinearService({ issue, project, updateIssue } as never);
+
+    await expect(service.removeIssueFromProject('ABC-123', 'project-1')).resolves.toEqual({
+      success: true,
+      issue: {
+        id: 'issue-1',
+        identifier: 'ABC-123',
+        title: 'Test issue',
+      },
+      project: {
+        id: 'project-1',
+        name: 'Roadmap',
+      },
+    });
+
+    expect(updateIssue).toHaveBeenCalledWith('issue-1', { projectId: null });
+  });
+
+  it('removes an issue from a cycle', async () => {
+    const issue = jest
+      .fn()
+      .mockResolvedValueOnce({
+        id: 'issue-1',
+        identifier: 'ABC-123',
+        title: 'Test issue',
+        cycle: Promise.resolve({
+          id: 'cycle-1',
+          number: 42,
+          name: 'Sprint 42',
+        }),
+      })
+      .mockResolvedValueOnce({
+        id: 'issue-1',
+        identifier: 'ABC-123',
+        title: 'Test issue',
+      });
+    const cycle = jest.fn().mockResolvedValue({
+      id: 'cycle-1',
+      number: 42,
+      name: 'Sprint 42',
+    });
+    const updateIssue = jest.fn().mockResolvedValue({ success: true });
+    const service = new LinearService({ issue, cycle, updateIssue } as never);
+
+    await expect(service.removeIssueFromCycle('ABC-123', 'cycle-1')).resolves.toEqual({
+      success: true,
+      issue: {
+        id: 'issue-1',
+        identifier: 'ABC-123',
+        title: 'Test issue',
+      },
+      cycle: {
+        id: 'cycle-1',
+        number: 42,
+        name: 'Sprint 42',
+      },
+    });
+
+    expect(updateIssue).toHaveBeenCalledWith('issue-1', { cycleId: null });
+  });
+});

--- a/src/__tests__/linear-service.test.ts
+++ b/src/__tests__/linear-service.test.ts
@@ -1,0 +1,118 @@
+import { LinearService } from '../services/linear-service.js';
+
+describe('LinearService optional field sanitization', () => {
+  it('omits empty optional fields when creating an issue', async () => {
+    const createIssue = jest.fn().mockResolvedValue({
+      success: true,
+      issue: Promise.resolve({
+        id: 'issue-1',
+        title: 'Test issue',
+        description: 'Body',
+        url: 'https://linear.app/issue-1',
+      }),
+    });
+    const service = new LinearService({ createIssue } as never);
+
+    await service.createIssue({
+      title: 'Test issue',
+      description: 'Body',
+      teamId: 'team-1',
+      assigneeId: '',
+      projectId: '',
+      cycleId: '',
+      dueDate: '',
+      labelIds: [],
+      parentId: '',
+      subscriberIds: [],
+      stateId: '',
+      templateId: '',
+    });
+
+    expect(createIssue).toHaveBeenCalledWith({
+      title: 'Test issue',
+      description: 'Body',
+      teamId: 'team-1',
+    });
+  });
+
+  it('omits empty optional fields and conflicting label arrays when updating an issue', async () => {
+    const updateIssue = jest.fn().mockResolvedValue({
+      success: true,
+      issue: Promise.resolve({
+        id: 'issue-1',
+        title: 'Updated issue',
+        description: 'Updated body',
+        url: 'https://linear.app/issue-1',
+      }),
+    });
+    const service = new LinearService({ updateIssue } as never);
+
+    await service.updateIssue({
+      id: 'issue-1',
+      stateId: 'state-1',
+      dueDate: '',
+      assigneeId: '',
+      cycleId: '',
+      parentId: '',
+      labelIds: ['label-1'],
+      addedLabelIds: [],
+      removedLabelIds: [],
+      subscriberIds: [],
+      teamId: '',
+    });
+
+    expect(updateIssue).toHaveBeenCalledWith('issue-1', {
+      stateId: 'state-1',
+      labelIds: ['label-1'],
+    });
+  });
+
+  it('prefers incremental label changes when provided for issue updates', async () => {
+    const updateIssue = jest.fn().mockResolvedValue({
+      success: true,
+      issue: Promise.resolve({
+        id: 'issue-1',
+        title: 'Updated issue',
+        description: 'Updated body',
+        url: 'https://linear.app/issue-1',
+      }),
+    });
+    const service = new LinearService({ updateIssue } as never);
+
+    await service.updateIssue({
+      id: 'issue-1',
+      labelIds: ['label-1'],
+      addedLabelIds: ['label-2'],
+      removedLabelIds: ['label-3'],
+    });
+
+    expect(updateIssue).toHaveBeenCalledWith('issue-1', {
+      addedLabelIds: ['label-2'],
+      removedLabelIds: ['label-3'],
+    });
+  });
+
+  it('omits empty parentId when creating a top-level comment', async () => {
+    const createComment = jest.fn().mockResolvedValue({
+      success: true,
+      comment: Promise.resolve({
+        id: 'comment-1',
+        body: 'hello',
+        url: 'https://linear.app/comment-1',
+        parent: null,
+      }),
+    });
+    const service = new LinearService({ createComment } as never);
+
+    await service.createComment({
+      issueId: 'issue-1',
+      body: 'hello',
+      parentId: '',
+    });
+
+    expect(createComment).toHaveBeenCalledWith({
+      issueId: 'issue-1',
+      body: 'hello',
+    });
+  });
+});

--- a/src/services/linear-service.ts
+++ b/src/services/linear-service.ts
@@ -1265,6 +1265,51 @@ export class LinearService {
   }
 
   /**
+   * Remove an issue from a project
+   * @param issueId ID of the issue to remove
+   * @param projectId ID of the project to remove the issue from
+   * @returns Success status and issue/project details
+   */
+  async removeIssueFromProject(issueId: string, projectId: string) {
+    try {
+      const issue = await this.client.issue(issueId);
+      if (!issue) {
+        throw new Error(`Issue with ID ${issueId} not found`);
+      }
+
+      const project = await this.client.project(projectId);
+      if (!project) {
+        throw new Error(`Project with ID ${projectId} not found`);
+      }
+
+      const currentProject = issue.project ? await issue.project : null;
+      if (!currentProject || currentProject.id !== projectId) {
+        throw new Error(`Issue ${issue.identifier} is not associated with project ${projectId}`);
+      }
+
+      await this.client.updateIssue(issue.id, { projectId: null });
+
+      const updatedIssue = await this.client.issue(issue.id);
+
+      return {
+        success: true,
+        issue: {
+          id: updatedIssue.id,
+          identifier: updatedIssue.identifier,
+          title: updatedIssue.title,
+        },
+        project: {
+          id: project.id,
+          name: project.name,
+        },
+      };
+    } catch (error) {
+      console.error('Error removing issue from project:', error);
+      throw error;
+    }
+  }
+
+  /**
    * Get all issues associated with a project
    * @param projectId ID of the project
    * @param limit Maximum number of issues to return
@@ -1471,6 +1516,52 @@ export class LinearService {
       };
     } catch (error) {
       console.error('Error adding issue to cycle:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Removes an issue from a cycle
+   * @param issueId ID or identifier of the issue
+   * @param cycleId ID of the cycle
+   * @returns Success status and updated issue information
+   */
+  async removeIssueFromCycle(issueId: string, cycleId: string) {
+    try {
+      const issue = await this.client.issue(issueId);
+      if (!issue) {
+        throw new Error(`Issue with ID ${issueId} not found`);
+      }
+
+      const cycle = await this.client.cycle(cycleId);
+      if (!cycle) {
+        throw new Error(`Cycle with ID ${cycleId} not found`);
+      }
+
+      const currentCycle = issue.cycle ? await issue.cycle : null;
+      if (!currentCycle || currentCycle.id !== cycleId) {
+        throw new Error(`Issue ${issue.identifier} is not associated with cycle ${cycleId}`);
+      }
+
+      await this.client.updateIssue(issue.id, { cycleId: null });
+
+      const updatedIssue = await this.client.issue(issue.id);
+
+      return {
+        success: true,
+        issue: {
+          id: updatedIssue.id,
+          identifier: updatedIssue.identifier,
+          title: updatedIssue.title,
+        },
+        cycle: {
+          id: cycle.id,
+          number: cycle.number,
+          name: cycle.name,
+        },
+      };
+    } catch (error) {
+      console.error('Error removing issue from cycle:', error);
       throw error;
     }
   }

--- a/src/services/linear-service.ts
+++ b/src/services/linear-service.ts
@@ -8,6 +8,59 @@ export class LinearService {
     this.client = client;
   }
 
+  private nonEmptyString(value: string | undefined): string | undefined {
+    return typeof value === 'string' && value.trim().length > 0 ? value : undefined;
+  }
+
+  private nonEmptyArray<T>(value: T[] | undefined): T[] | undefined {
+    return Array.isArray(value) && value.length > 0 ? value : undefined;
+  }
+
+  private compactIssueInput<T extends {
+    assigneeId?: string;
+    projectId?: string;
+    cycleId?: string;
+    dueDate?: string;
+    labelIds?: string[];
+    addedLabelIds?: string[];
+    removedLabelIds?: string[];
+    parentId?: string;
+    subscriberIds?: string[];
+    stateId?: string;
+    templateId?: string;
+    teamId?: string;
+  }>(input: T): T {
+    const compacted = {
+      ...input,
+      assigneeId: this.nonEmptyString(input.assigneeId),
+      projectId: this.nonEmptyString(input.projectId),
+      cycleId: this.nonEmptyString(input.cycleId),
+      dueDate: this.nonEmptyString(input.dueDate),
+      parentId: this.nonEmptyString(input.parentId),
+      subscriberIds: this.nonEmptyArray(input.subscriberIds),
+      stateId: this.nonEmptyString(input.stateId),
+      templateId: this.nonEmptyString(input.templateId),
+      teamId: this.nonEmptyString(input.teamId),
+    } as T;
+
+    const addedLabelIds = this.nonEmptyArray(input.addedLabelIds);
+    const removedLabelIds = this.nonEmptyArray(input.removedLabelIds);
+
+    if (addedLabelIds || removedLabelIds) {
+      compacted.addedLabelIds = addedLabelIds as T['addedLabelIds'];
+      compacted.removedLabelIds = removedLabelIds as T['removedLabelIds'];
+      compacted.labelIds = undefined;
+    } else {
+      compacted.labelIds = this.nonEmptyArray(input.labelIds) as T['labelIds'];
+      compacted.addedLabelIds = undefined;
+      compacted.removedLabelIds = undefined;
+    }
+
+    return Object.fromEntries(
+      Object.entries(compacted).filter(([, value]) => value !== undefined),
+    ) as T;
+  }
+
   async getUserInfo() {
     const viewer = await this.client.viewer;
     return {
@@ -434,7 +487,7 @@ export class LinearService {
     templateId?: string;
     sortOrder?: number;
   }) {
-    const createdIssue = await this.client.createIssue({
+    const createdIssue = await this.client.createIssue(this.compactIssueInput({
       title: args.title,
       description: args.description,
       teamId: args.teamId,
@@ -450,7 +503,7 @@ export class LinearService {
       stateId: args.stateId,
       templateId: args.templateId,
       sortOrder: args.sortOrder,
-    });
+    }));
 
     // Access the issue from the payload
     if (createdIssue.success && createdIssue.issue) {
@@ -485,7 +538,7 @@ export class LinearService {
     teamId?: string;
     sortOrder?: number;
   }) {
-    const updatedIssue = await this.client.updateIssue(args.id, {
+    const updatedIssue = await this.client.updateIssue(args.id, this.compactIssueInput({
       title: args.title,
       description: args.description,
       stateId: args.stateId,
@@ -502,7 +555,7 @@ export class LinearService {
       subscriberIds: args.subscriberIds,
       teamId: args.teamId,
       sortOrder: args.sortOrder,
-    });
+    }));
 
     if (updatedIssue.success && updatedIssue.issue) {
       const issueData = await updatedIssue.issue;
@@ -521,7 +574,7 @@ export class LinearService {
     const createdComment = await this.client.createComment({
       issueId: args.issueId,
       body: args.body,
-      parentId: args.parentId,
+      ...(this.nonEmptyString(args.parentId) ? { parentId: this.nonEmptyString(args.parentId) } : {}),
     });
 
     if (createdComment.success && createdComment.comment) {

--- a/src/tools/definitions/cycle-tools.ts
+++ b/src/tools/definitions/cycle-tools.ts
@@ -127,3 +127,47 @@ export const addIssueToCycleToolDefinition: MCPToolDefinition = {
     },
   },
 };
+
+/**
+ * Tool definition for removing an issue from a cycle
+ */
+export const removeIssueFromCycleToolDefinition: MCPToolDefinition = {
+  name: 'linear_removeIssueFromCycle',
+  description: 'Remove an issue from a cycle',
+  input_schema: {
+    type: 'object',
+    properties: {
+      issueId: {
+        type: 'string',
+        description: 'ID or identifier of the issue to remove from the cycle',
+      },
+      cycleId: {
+        type: 'string',
+        description: 'ID of the cycle to remove the issue from',
+      },
+    },
+    required: ['issueId', 'cycleId'],
+  },
+  output_schema: {
+    type: 'object',
+    properties: {
+      success: { type: 'boolean' },
+      issue: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          identifier: { type: 'string' },
+          title: { type: 'string' },
+        },
+      },
+      cycle: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          number: { type: 'number' },
+          name: { type: 'string' },
+        },
+      },
+    },
+  },
+};

--- a/src/tools/definitions/index.ts
+++ b/src/tools/definitions/index.ts
@@ -27,6 +27,7 @@ import {
   // Project Management tools
   updateProjectToolDefinition,
   addIssueToProjectToolDefinition,
+  removeIssueFromProjectToolDefinition,
   getProjectIssuesToolDefinition,
 } from './project-tools.js';
 import { getTeamsToolDefinition, getWorkflowStatesToolDefinition } from './team-tools.js';
@@ -41,6 +42,7 @@ import {
   getCyclesToolDefinition,
   getActiveCycleToolDefinition,
   addIssueToCycleToolDefinition,
+  removeIssueFromCycleToolDefinition,
 } from './cycle-tools.js';
 import { initiativeToolDefinitions } from './initiative-tools.js';
 
@@ -63,12 +65,14 @@ export const allToolDefinitions: MCPToolDefinition[] = [
   // Project Management tools
   updateProjectToolDefinition,
   addIssueToProjectToolDefinition,
+  removeIssueFromProjectToolDefinition,
   getProjectIssuesToolDefinition,
 
   // Cycle Management tools
   getCyclesToolDefinition,
   getActiveCycleToolDefinition,
   addIssueToCycleToolDefinition,
+  removeIssueFromCycleToolDefinition,
 
   // Initiative Management tools
   ...initiativeToolDefinitions,
@@ -134,10 +138,12 @@ export {
   // Project Management tools
   updateProjectToolDefinition,
   addIssueToProjectToolDefinition,
+  removeIssueFromProjectToolDefinition,
   getProjectIssuesToolDefinition,
 
   // Cycle Management tools
   getCyclesToolDefinition,
   getActiveCycleToolDefinition,
   addIssueToCycleToolDefinition,
+  removeIssueFromCycleToolDefinition,
 };

--- a/src/tools/definitions/project-tools.ts
+++ b/src/tools/definitions/project-tools.ts
@@ -169,6 +169,49 @@ export const addIssueToProjectToolDefinition: MCPToolDefinition = {
 };
 
 /**
+ * Tool definition for removing an issue from a project
+ */
+export const removeIssueFromProjectToolDefinition: MCPToolDefinition = {
+  name: 'linear_removeIssueFromProject',
+  description: 'Remove an existing issue from a project',
+  input_schema: {
+    type: 'object',
+    properties: {
+      issueId: {
+        type: 'string',
+        description: 'ID or identifier of the issue to remove from the project',
+      },
+      projectId: {
+        type: 'string',
+        description: 'ID of the project to remove the issue from',
+      },
+    },
+    required: ['issueId', 'projectId'],
+  },
+  output_schema: {
+    type: 'object',
+    properties: {
+      success: { type: 'boolean' },
+      issue: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          identifier: { type: 'string' },
+          title: { type: 'string' },
+        },
+      },
+      project: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          name: { type: 'string' },
+        },
+      },
+    },
+  },
+};
+
+/**
  * Tool definition for getting issues in a project
  */
 export const getProjectIssuesToolDefinition: MCPToolDefinition = {

--- a/src/tools/handlers/cycle-handlers.ts
+++ b/src/tools/handlers/cycle-handlers.ts
@@ -1,4 +1,9 @@
-import { isAddIssueToCycleArgs, isGetActiveCycleArgs, isGetCyclesArgs } from '../type-guards.js';
+import {
+  isAddIssueToCycleArgs,
+  isGetActiveCycleArgs,
+  isGetCyclesArgs,
+  isRemoveIssueFromCycleArgs,
+} from '../type-guards.js';
 import { LinearService } from '../../services/linear-service.js';
 import { logError } from '../../utils/config.js';
 
@@ -51,6 +56,24 @@ export function handleAddIssueToCycle(linearService: LinearService) {
       return await linearService.addIssueToCycle(args.issueId, args.cycleId);
     } catch (error) {
       logError('Error adding issue to cycle', error);
+      throw error;
+    }
+  };
+}
+
+/**
+ * Handler for removing an issue from a cycle
+ */
+export function handleRemoveIssueFromCycle(linearService: LinearService) {
+  return async (args: unknown) => {
+    try {
+      if (!isRemoveIssueFromCycleArgs(args)) {
+        throw new Error('Invalid arguments for removeIssueFromCycle');
+      }
+
+      return await linearService.removeIssueFromCycle(args.issueId, args.cycleId);
+    } catch (error) {
+      logError('Error removing issue from cycle', error);
       throw error;
     }
   };

--- a/src/tools/handlers/index.ts
+++ b/src/tools/handlers/index.ts
@@ -27,6 +27,7 @@ import {
   // Project Management handlers
   handleUpdateProject,
   handleAddIssueToProject,
+  handleRemoveIssueFromProject,
   handleGetProjectIssues,
 } from './project-handlers.js';
 import { handleGetTeams, handleGetWorkflowStates } from './team-handlers.js';
@@ -41,6 +42,7 @@ import {
   handleGetCycles,
   handleGetActiveCycle,
   handleAddIssueToCycle,
+  handleRemoveIssueFromCycle,
 } from './cycle-handlers.js';
 import {
   // Initiative Management handlers
@@ -80,12 +82,14 @@ export function registerToolHandlers(linearService: LinearService) {
     // Project Management tools
     linear_updateProject: handleUpdateProject(linearService),
     linear_addIssueToProject: handleAddIssueToProject(linearService),
+    linear_removeIssueFromProject: handleRemoveIssueFromProject(linearService),
     linear_getProjectIssues: handleGetProjectIssues(linearService),
 
     // Cycle Management tools
     linear_getCycles: handleGetCycles(linearService),
     linear_getActiveCycle: handleGetActiveCycle(linearService),
     linear_addIssueToCycle: handleAddIssueToCycle(linearService),
+    linear_removeIssueFromCycle: handleRemoveIssueFromCycle(linearService),
 
     // Initiative Management tools
     linear_getInitiatives: getInitiativesHandler(linearService),
@@ -161,12 +165,14 @@ export {
   // Project Management handlers
   handleUpdateProject,
   handleAddIssueToProject,
+  handleRemoveIssueFromProject,
   handleGetProjectIssues,
 
   // Cycle Management handlers
   handleGetCycles,
   handleGetActiveCycle,
   handleAddIssueToCycle,
+  handleRemoveIssueFromCycle,
 
   // Initiative Management handlers
   getInitiativesHandler,

--- a/src/tools/handlers/project-handlers.ts
+++ b/src/tools/handlers/project-handlers.ts
@@ -2,6 +2,7 @@ import {
   isAddIssueToProjectArgs,
   isCreateProjectArgs,
   isGetProjectIssuesArgs,
+  isRemoveIssueFromProjectArgs,
   isUpdateProjectArgs,
 } from '../type-guards.js';
 import { LinearService } from '../../services/linear-service.js';
@@ -70,6 +71,24 @@ export function handleAddIssueToProject(linearService: LinearService) {
       return await linearService.addIssueToProject(args.issueId, args.projectId);
     } catch (error) {
       logError('Error adding issue to project', error);
+      throw error;
+    }
+  };
+}
+
+/**
+ * Handler for removing an issue from a project
+ */
+export function handleRemoveIssueFromProject(linearService: LinearService) {
+  return async (args: unknown) => {
+    try {
+      if (!isRemoveIssueFromProjectArgs(args)) {
+        throw new Error('Invalid arguments for removeIssueFromProject');
+      }
+
+      return await linearService.removeIssueFromProject(args.issueId, args.projectId);
+    } catch (error) {
+      logError('Error removing issue from project', error);
       throw error;
     }
   };

--- a/src/tools/type-guards.ts
+++ b/src/tools/type-guards.ts
@@ -461,6 +461,23 @@ export function isAddIssueToProjectArgs(args: unknown): args is {
 }
 
 /**
+ * Type guard for linear_removeIssueFromProject tool arguments
+ */
+export function isRemoveIssueFromProjectArgs(args: unknown): args is {
+  issueId: string;
+  projectId: string;
+} {
+  return (
+    typeof args === 'object' &&
+    args !== null &&
+    'issueId' in args &&
+    typeof (args as { issueId: string }).issueId === 'string' &&
+    'projectId' in args &&
+    typeof (args as { projectId: string }).projectId === 'string'
+  );
+}
+
+/**
  * Type guard for linear_getProjectIssues tool arguments
  */
 export function isGetProjectIssuesArgs(args: unknown): args is {
@@ -678,6 +695,23 @@ export function isGetActiveCycleArgs(args: unknown): args is {
  * Type guard for linear_addIssueToCycle tool arguments
  */
 export function isAddIssueToCycleArgs(args: unknown): args is {
+  issueId: string;
+  cycleId: string;
+} {
+  return (
+    typeof args === 'object' &&
+    args !== null &&
+    'issueId' in args &&
+    typeof (args as { issueId: string }).issueId === 'string' &&
+    'cycleId' in args &&
+    typeof (args as { cycleId: string }).cycleId === 'string'
+  );
+}
+
+/**
+ * Type guard for linear_removeIssueFromCycle tool arguments
+ */
+export function isRemoveIssueFromCycleArgs(args: unknown): args is {
   issueId: string;
   cycleId: string;
 } {


### PR DESCRIPTION
## Summary
- add `linear_removeIssueFromProject` and `linear_removeIssueFromCycle` across the service, tool definitions, handlers, type guards, and registrations
- clear project and cycle scope only after verifying the issue is currently linked to the requested target
- update Smithery/TOOLS metadata and add focused unlink tests, with `npm test` and `npm run build` passing