### PR TITLE
fix: replace console.log with console.error in handlers (fixes -32000 crashes)

### DIFF
--- a/src/tools/handlers/initiative-handlers.ts
+++ b/src/tools/handlers/initiative-handlers.ts
@@ -17,9 +17,9 @@ export function getInitiativesHandler(linearService: LinearService) {
       throw new Error('Invalid input for getInitiatives');
     }
 
-    console.log('[getInitiatives] Fetching initiatives with options:', args);
+    console.error('[getInitiatives] Fetching initiatives with options:', args);
     const initiatives = await linearService.getInitiatives(args);
-    console.log(`[getInitiatives] Retrieved ${initiatives.length} initiatives`);
+    console.error(`[getInitiatives] Retrieved ${initiatives.length} initiatives`);
     return initiatives;
   };
 }
@@ -30,12 +30,12 @@ export function getInitiativeByIdHandler(linearService: LinearService) {
       throw new Error('Invalid input for getInitiativeById');
     }
 
-    console.log(`[getInitiativeById] Fetching initiative: ${args.initiativeId}`);
+    console.error(`[getInitiativeById] Fetching initiative: ${args.initiativeId}`);
     const initiative = await linearService.getInitiativeById(
       args.initiativeId,
       args.includeProjects,
     );
-    console.log(`[getInitiativeById] Retrieved initiative: ${initiative.name}`);
+    console.error(`[getInitiativeById] Retrieved initiative: ${initiative.name}`);
     return initiative;
   };
 }
@@ -46,9 +46,9 @@ export function createInitiativeHandler(linearService: LinearService) {
       throw new Error('Invalid input for createInitiative');
     }
 
-    console.log('[createInitiative] Creating new initiative:', args.name);
+    console.error('[createInitiative] Creating new initiative:', args.name);
     const result = await linearService.createInitiative(args);
-    console.log(`[createInitiative] Initiative created successfully`);
+    console.error(`[createInitiative] Initiative created successfully`);
     return result;
   };
 }
@@ -60,9 +60,9 @@ export function updateInitiativeHandler(linearService: LinearService) {
     }
 
     const { initiativeId, ...updateData } = args;
-    console.log(`[updateInitiative] Updating initiative: ${initiativeId}`);
+    console.error(`[updateInitiative] Updating initiative: ${initiativeId}`);
     const result = await linearService.updateInitiative(initiativeId, updateData);
-    console.log(`[updateInitiative] Initiative updated successfully`);
+    console.error(`[updateInitiative] Initiative updated successfully`);
     return result;
   };
 }
@@ -73,9 +73,9 @@ export function archiveInitiativeHandler(linearService: LinearService) {
       throw new Error('Invalid input for archiveInitiative');
     }
 
-    console.log(`[archiveInitiative] Archiving initiative: ${args.initiativeId}`);
+    console.error(`[archiveInitiative] Archiving initiative: ${args.initiativeId}`);
     const result = await linearService.archiveInitiative(args.initiativeId);
-    console.log(`[archiveInitiative] Initiative archived successfully`);
+    console.error(`[archiveInitiative] Initiative archived successfully`);
     return result;
   };
 }
@@ -86,9 +86,9 @@ export function unarchiveInitiativeHandler(linearService: LinearService) {
       throw new Error('Invalid input for unarchiveInitiative');
     }
 
-    console.log(`[unarchiveInitiative] Unarchiving initiative: ${args.initiativeId}`);
+    console.error(`[unarchiveInitiative] Unarchiving initiative: ${args.initiativeId}`);
     const result = await linearService.unarchiveInitiative(args.initiativeId);
-    console.log(`[unarchiveInitiative] Initiative unarchived successfully`);
+    console.error(`[unarchiveInitiative] Initiative unarchived successfully`);
     return result;
   };
 }
@@ -99,9 +99,9 @@ export function deleteInitiativeHandler(linearService: LinearService) {
       throw new Error('Invalid input for deleteInitiative');
     }
 
-    console.log(`[deleteInitiative] Deleting initiative: ${args.initiativeId}`);
+    console.error(`[deleteInitiative] Deleting initiative: ${args.initiativeId}`);
     const result = await linearService.deleteInitiative(args.initiativeId);
-    console.log(`[deleteInitiative] Initiative deleted successfully`);
+    console.error(`[deleteInitiative] Initiative deleted successfully`);
     return result;
   };
 }
@@ -112,12 +112,12 @@ export function getInitiativeProjectsHandler(linearService: LinearService) {
       throw new Error('Invalid input for getInitiativeProjects');
     }
 
-    console.log(`[getInitiativeProjects] Fetching projects for initiative: ${args.initiativeId}`);
+    console.error(`[getInitiativeProjects] Fetching projects for initiative: ${args.initiativeId}`);
     const projects = await linearService.getInitiativeProjects(
       args.initiativeId,
       args.includeArchived,
     );
-    console.log(`[getInitiativeProjects] Retrieved ${projects.length} projects`);
+    console.error(`[getInitiativeProjects] Retrieved ${projects.length} projects`);
     return projects;
   };
 }
@@ -128,11 +128,11 @@ export function addProjectToInitiativeHandler(linearService: LinearService) {
       throw new Error('Invalid input for addProjectToInitiative');
     }
 
-    console.log(
+    console.error(
       `[addProjectToInitiative] Adding project ${args.projectId} to initiative ${args.initiativeId}`,
     );
     const result = await linearService.addProjectToInitiative(args.initiativeId, args.projectId);
-    console.log(`[addProjectToInitiative] Project added successfully`);
+    console.error(`[addProjectToInitiative] Project added successfully`);
     return result;
   };
 }
@@ -143,14 +143,14 @@ export function removeProjectFromInitiativeHandler(linearService: LinearService)
       throw new Error('Invalid input for removeProjectFromInitiative');
     }
 
-    console.log(
+    console.error(
       `[removeProjectFromInitiative] Removing project ${args.projectId} from initiative ${args.initiativeId}`,
     );
     const result = await linearService.removeProjectFromInitiative(
       args.initiativeId,
       args.projectId,
     );
-    console.log(`[removeProjectFromInitiative] Project removed successfully`);
+    console.error(`[removeProjectFromInitiative] Project removed successfully`);
     return result;
   };
 }

--- a/src/tools/handlers/issue-handlers.ts
+++ b/src/tools/handlers/issue-handlers.ts
@@ -63,14 +63,14 @@ export function handleGetIssueById(linearService: LinearService) {
 export function handleSearchIssues(linearService: LinearService) {
   return async (args: unknown) => {
     try {
-      console.log('searchIssues args:', JSON.stringify(args, null, 2));
+      console.error('searchIssues args:', JSON.stringify(args, null, 2));
 
       if (!isSearchIssuesArgs(args)) {
         console.error('Invalid arguments for searchIssues');
         throw new Error('Invalid arguments for searchIssues');
       }
 
-      console.log('Arguments validated successfully');
+      console.error('Arguments validated successfully');
       return await linearService.searchIssues(args);
     } catch (error) {
       logError('Error searching issues', error);


### PR DESCRIPTION
## Problem

\`console.log()\` writes to **stdout**, which on stdio MCP servers is reserved for JSON-RPC protocol messages. Any debug output on stdout corrupts the framing — Claude Code surfaces this as \`MCP error -32000: Connection closed\` and the whole MCP server becomes unusable until \`/mcp\` reconnect.

This explains several open reports:

- #11 — \`getLabels()\` always crashes the mcp server (almost certainly same root cause; \`getLabels\` may have similar logs in its path or trigger the parser-state issue indirectly)
- #8 — \`Client Closed\` error in Cursor (Cursor surfaces the same corruption with a different error string)
- Reproducible deterministic crash on \`linear_searchIssues\` for any workspace with non-trivial issue counts (Schoolwise: ~61 open issues with long markdown bodies → 124KB response → \`-32000\` every single call until this patch)

## Why \`searchIssues\` is the most reliable repro

Two \`console.log\` calls fire on every single \`searchIssues\` invocation (\`'searchIssues args:'\` and \`'Arguments validated successfully'\`), and the response payload is large enough that the corrupted JSON-RPC frame can't recover. Smaller calls like \`getViewer\` don't hit a logging handler at all, which is why they appear to work.

## The fix

One-line replacement: \`console.log\` → \`console.error\` in \`src/tools/handlers/initiative-handlers.ts\` (20 calls) and \`src/tools/handlers/issue-handlers.ts\` (2 calls). \`stderr\` is never read by the MCP transport and is the standard Node.js channel for diagnostic logs. This is also the official guidance in the [\`@modelcontextprotocol/typescript-sdk\` README](https://github.com/modelcontextprotocol/typescript-sdk) and the MCP spec.

\`type-guards.ts\` already correctly uses \`console.error\` for its validation logs — so this PR brings the handler files in line with the existing convention in the rest of the codebase.

## Verification

Post-patch, the exact \`linear_searchIssues({states: ["In Progress", "Todo", "Backlog"], limit: 50})\` call that crashed every time before now returns ~124KB of data cleanly. Multiple sequential heavy queries succeed in a row across both \`linear-schoolwise\` and \`linear-personal\` workspaces.

## What this doesn't fix

- Other instances of \`console.log\` outside handlers (services/, utils/) — should follow up if any exist on hot paths.
- The MCP server doesn't currently use a structured logger. A separate cleanup PR could route everything through a single debug channel (e.g., \`debug\` package gated by an env var). Out of scope for this fix.

Closes #11 (likely; should be verified by the original reporter on \`getLabels\`).