### PR TITLE
Fix CI hang: exit on termination signals and watchdog smoke test

### DIFF
--- a/scripts/mcp-smoke-test.mjs
+++ b/scripts/mcp-smoke-test.mjs
@@ -95,7 +95,21 @@ async function main() {
   }
 }
 
-main().catch((error) => {
-  console.error('MCP smoke test failed:', error);
-  process.exit(1);
-});
+// Hard timeout so a stuck child process can never hang CI for hours.
+const SMOKE_TEST_TIMEOUT_MS = 60_000;
+const watchdog = setTimeout(() => {
+  console.error(`MCP smoke test timed out after ${SMOKE_TEST_TIMEOUT_MS}ms`);
+  process.exit(2);
+}, SMOKE_TEST_TIMEOUT_MS);
+watchdog.unref();
+
+main()
+  .then(() => {
+    clearTimeout(watchdog);
+    process.exit(0);
+  })
+  .catch((error) => {
+    clearTimeout(watchdog);
+    console.error('MCP smoke test failed:', error);
+    process.exit(1);
+  });

--- a/src/runtime-diagnostics.ts
+++ b/src/runtime-diagnostics.ts
@@ -21,9 +21,14 @@ export function installRuntimeDiagnostics() {
     logInfo(`MCP Linear exit with code ${code}`);
   });
 
+  // Log the signal then exit. Without the explicit exit Node treats the
+  // registered handler as overriding default termination behavior, which
+  // makes the server ignore SIGTERM/SIGINT/SIGHUP and hang in CI when
+  // the smoke test or a parent process tries to shut it down.
   for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP'] as const) {
     process.on(signal, () => {
       logInfo(`MCP Linear received ${signal}`);
+      process.exit(0);
     });
   }
 }


### PR DESCRIPTION
## Summary

The publish workflow's `Run tests` step has been hanging until workflow timeout (see [run 25289051470](https://github.com/tacticlaunch/mcp-linear/actions/runs/25289051470/job/74137889454)). Root cause: the `SIGINT`/`SIGTERM`/`SIGHUP` handlers added in `src/runtime-diagnostics.ts` only log the signal name and never call `process.exit`. Registering a handler that does not exit overrides Node's default termination behavior, so the server ignores shutdown signals. The MCP SDK smoke test sends `SIGTERM` to the child server via `StdioClientTransport.close`, the child stays alive, and the parent's pipes never close — CI hangs.

## Changes

- `src/runtime-diagnostics.ts`: log the signal then `process.exit(0)`, restoring expected shutdown behavior.
- `scripts/mcp-smoke-test.mjs`: 60-second hard watchdog so any future regression in shutdown can never hang CI for hours; on success the script also calls `process.exit(0)` explicitly so a stuck transport handle cannot keep the process alive.

## Validation

- `npm run test:mcp-smoke` locally now completes in ~0.2s (previously hung).
- No tool/resource/prompt assertions or contracts changed.

## Test plan

- [ ] `Publish to npm` workflow completes the `Run tests` step
- [ ] Local `npm run test:mcp-smoke` exits cleanly