### PR TITLE
Return real relation id and identifiers from createIssueRelation

### DIFF
--- a/src/__tests__/issue-relation.test.ts
+++ b/src/__tests__/issue-relation.test.ts
@@ -1,0 +1,157 @@
+import { LinearService } from '../services/linear-service.js';
+
+type IssueLike = { id: string; identifier: string };
+
+function buildPayload(opts: {
+  relationId: string;
+  type: string;
+  source: IssueLike;
+  target: IssueLike;
+  success?: boolean;
+}) {
+  return {
+    success: opts.success ?? true,
+    issueRelation: Promise.resolve({
+      id: opts.relationId,
+      type: opts.type,
+      issue: Promise.resolve(opts.source),
+      relatedIssue: Promise.resolve(opts.target),
+    }),
+  };
+}
+
+function makeClient(opts: {
+  issuesById: Record<string, IssueLike>;
+  capture?: (input: Record<string, unknown>) => void;
+  payload: ReturnType<typeof buildPayload>;
+}) {
+  return {
+    issue: jest.fn(async (id: string) => opts.issuesById[id] ?? null),
+    createIssueRelation: jest.fn(async (input: Record<string, unknown>) => {
+      opts.capture?.(input);
+      return opts.payload;
+    }),
+  } as unknown as ConstructorParameters<typeof LinearService>[0];
+}
+
+describe('LinearService.createIssueRelation', () => {
+  const sourceIssue: IssueLike = { id: 'issue-A', identifier: 'COCO-34' };
+  const targetIssue: IssueLike = { id: 'issue-B', identifier: 'COCO-33' };
+
+  it('returns a flat relation with the real id and identifiers for "blocks"', async () => {
+    let captured: Record<string, unknown> | undefined;
+    const service = new LinearService(
+      makeClient({
+        issuesById: { 'issue-A': sourceIssue, 'issue-B': targetIssue },
+        capture: (input) => (captured = input),
+        payload: buildPayload({
+          relationId: 'rel-123',
+          type: 'blocks',
+          source: sourceIssue,
+          target: targetIssue,
+        }),
+      }),
+    );
+
+    const result = await service.createIssueRelation('issue-A', 'issue-B', 'blocks');
+
+    expect(captured).toEqual({ issueId: 'issue-A', relatedIssueId: 'issue-B', type: 'blocks' });
+    expect(result).toEqual({
+      success: true,
+      relation: {
+        id: 'rel-123',
+        type: 'blocks',
+        issueIdentifier: 'COCO-34',
+        relatedIssueIdentifier: 'COCO-33',
+      },
+    });
+    // Regression: must not return the legacy placeholder.
+    expect(result.relation?.id).not.toBe('relation-id-would-go-here');
+  });
+
+  it('maps "blocked_by" to "blocks" with swapped issues', async () => {
+    let captured: Record<string, unknown> | undefined;
+    const service = new LinearService(
+      makeClient({
+        issuesById: { 'issue-A': sourceIssue, 'issue-B': targetIssue },
+        capture: (input) => (captured = input),
+        payload: buildPayload({
+          relationId: 'rel-456',
+          type: 'blocks',
+          source: targetIssue,
+          target: sourceIssue,
+        }),
+      }),
+    );
+
+    const result = await service.createIssueRelation('issue-A', 'issue-B', 'blocked_by');
+
+    expect(captured).toEqual({ issueId: 'issue-B', relatedIssueId: 'issue-A', type: 'blocks' });
+    expect(result.relation?.issueIdentifier).toBe('COCO-33');
+    expect(result.relation?.relatedIssueIdentifier).toBe('COCO-34');
+  });
+
+  it('maps "duplicate_of" to "duplicate" with swapped issues', async () => {
+    let captured: Record<string, unknown> | undefined;
+    const service = new LinearService(
+      makeClient({
+        issuesById: { 'issue-A': sourceIssue, 'issue-B': targetIssue },
+        capture: (input) => (captured = input),
+        payload: buildPayload({
+          relationId: 'rel-789',
+          type: 'duplicate',
+          source: targetIssue,
+          target: sourceIssue,
+        }),
+      }),
+    );
+
+    await service.createIssueRelation('issue-A', 'issue-B', 'duplicate_of');
+
+    expect(captured).toEqual({ issueId: 'issue-B', relatedIssueId: 'issue-A', type: 'duplicate' });
+  });
+
+  it('rejects unknown relation types', async () => {
+    const service = new LinearService(
+      makeClient({
+        issuesById: { 'issue-A': sourceIssue, 'issue-B': targetIssue },
+        payload: buildPayload({
+          relationId: 'rel-x',
+          type: 'blocks',
+          source: sourceIssue,
+          target: targetIssue,
+        }),
+      }),
+    );
+
+    await expect(
+      service.createIssueRelation('issue-A', 'issue-B', 'cousin_of'),
+    ).rejects.toThrow('cousin_of is not a valid relation type');
+  });
+
+  it('falls back to the looked-up identifiers when the SDK cannot resolve the related issues', async () => {
+    const service = new LinearService(
+      makeClient({
+        issuesById: { 'issue-A': sourceIssue, 'issue-B': targetIssue },
+        payload: {
+          success: true,
+          issueRelation: Promise.resolve({
+            id: 'rel-fallback',
+            type: 'related',
+            issue: undefined,
+            relatedIssue: undefined,
+          }),
+        } as ReturnType<typeof buildPayload>,
+      }),
+    );
+
+    const result = await service.createIssueRelation('issue-A', 'issue-B', 'related');
+
+    expect(result.relation).toEqual({
+      id: 'rel-fallback',
+      type: 'related',
+      issueIdentifier: 'COCO-34',
+      relatedIssueIdentifier: 'COCO-33',
+    });
+  });
+});

--- a/src/services/linear-service.ts
+++ b/src/services/linear-service.ts
@@ -5400,37 +5400,71 @@ export class LinearService {
    */
   async createIssueRelation(issueId: string, relatedIssueId: string, relationType: string) {
     try {
-      // Get both issues
-      const issue = await this.client.issue(issueId);
-      if (!issue) {
-        throw new Error(`Issue with ID ${issueId} not found`);
+      // Linear's IssueRelationType enum only contains "blocks" | "duplicate" | "related".
+      // The tool advertises "blocked_by" and "duplicate_of" as user-friendly aliases;
+      // implement them by swapping the issue/relatedIssue and using the canonical type.
+      let sourceIssueId = issueId;
+      let targetIssueId = relatedIssueId;
+      let canonicalType: 'blocks' | 'duplicate' | 'related';
+      switch (relationType) {
+        case 'blocks':
+        case 'duplicate':
+        case 'related':
+          canonicalType = relationType;
+          break;
+        case 'blocked_by':
+          canonicalType = 'blocks';
+          sourceIssueId = relatedIssueId;
+          targetIssueId = issueId;
+          break;
+        case 'duplicate_of':
+          canonicalType = 'duplicate';
+          sourceIssueId = relatedIssueId;
+          targetIssueId = issueId;
+          break;
+        default:
+          throw new Error(`${relationType} is not a valid relation type`);
       }
 
-      const relatedIssue = await this.client.issue(relatedIssueId);
-      if (!relatedIssue) {
-        throw new Error(`Related issue with ID ${relatedIssueId} not found`);
+      const sourceIssue = await this.client.issue(sourceIssueId);
+      if (!sourceIssue) {
+        throw new Error(`Issue with ID ${sourceIssueId} not found`);
+      }
+      const targetIssue = await this.client.issue(targetIssueId);
+      if (!targetIssue) {
+        throw new Error(`Related issue with ID ${targetIssueId} not found`);
       }
 
-      const validTypes = ["blocks", "duplicate", "related"];
-      
-      if (!validTypes.includes(relationType)) {
-        throw new Error(`${relationType} is not a valid relation type`)
+      const payload = await this.client.createIssueRelation({
+        issueId: sourceIssueId,
+        relatedIssueId: targetIssueId,
+        // Linear's IssueRelationType is `blocks` | `duplicate` | `related`; the SDK
+        // accepts the string form here without needing the runtime enum import.
+        type: canonicalType as unknown as never,
+      });
+
+      const issueRelation = payload.issueRelation ? await payload.issueRelation : null;
+      if (!issueRelation) {
+        return {
+          success: payload.success === true,
+          relation: null,
+        };
       }
 
-      const relation = await this.client.createIssueRelation({
-        issueId,
-        relatedIssueId,
-        // @ts-ignore
-        type: relationType, 
-      })
-
-      // For now, we'll just acknowledge the request with a success message
-      // The actual relation creation logic would need to be implemented based on the Linear SDK specifics
-      // In a production environment, we should check the SDK documentation for the correct method
+      // Resolve the lazy issue/relatedIssue fields so we can expose stable identifiers.
+      const [resolvedSource, resolvedTarget] = await Promise.all([
+        issueRelation.issue ? await issueRelation.issue : null,
+        issueRelation.relatedIssue ? await issueRelation.relatedIssue : null,
+      ]);
 
       return {
-        success: true,
-        relation,
+        success: payload.success === true,
+        relation: {
+          id: issueRelation.id,
+          type: issueRelation.type,
+          issueIdentifier: resolvedSource?.identifier ?? sourceIssue.identifier,
+          relatedIssueIdentifier: resolvedTarget?.identifier ?? targetIssue.identifier,
+        },
       };
     } catch (error) {
       console.error('Error creating issue relation:', error);


### PR DESCRIPTION
## Summary

Closes [#9](https://github.com/tacticlaunch/mcp-linear/issues/9). The previous implementation of `LinearService.createIssueRelation` returned the raw Linear SDK `IssueRelationPayload` (with a lazy getter for `issueRelation`), and earlier versions returned a placeholder string in place of the relation id.

This PR:

- Resolves the lazy `issueRelation`, `issue`, and `relatedIssue` references and returns the flat shape that the tool's `output_schema` already declares: `{ success, relation: { id, type, issueIdentifier, relatedIssueIdentifier } }`.
- Accepts `blocked_by` and `duplicate_of` (which the tool already advertises) by swapping the source/target issues and submitting the canonical Linear type. Linear's `IssueRelationType` only contains `blocks`, `duplicate`, and `related`, so the aliases must be expressed as inverses of those three.

## Tests

New `src/__tests__/issue-relation.test.ts` covering:

- the happy path returns a real id (regression assertion explicitly excludes the legacy `relation-id-would-go-here` placeholder)
- `blocked_by` and `duplicate_of` swap issue ids and submit the canonical type
- unknown relation types are rejected
- when the SDK can't resolve the related issues, identifiers fall back to the looked-up source/target

## Test plan

- [x] `npm run build` passes
- [ ] Unit suite (incl. new `issue-relation.test.ts`) passes
- [ ] MCP smoke test passes
- [ ] Live verification: `linear_createIssueRelation` against a real workspace returns a real UUID and the correct identifiers