### PR TITLE
ci: use npm trusted publishing

### DIFF
--- a/.github/workflows/publish-existing.yml
+++ b/.github/workflows/publish-existing.yml
@@ -1,0 +1,42 @@
+name: Publish existing npm release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Existing package version to publish (for example, 1.4.1)'
+        required: true
+        type: string
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v4
+        with:
+          ref: v${{ inputs.version }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24.x'
+          registry-url: 'https://registry.npmjs.org/'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+      - name: Verify package version
+        run: test "$(node -p \"require('./package.json').version\")" = "${{ inputs.version }}"
+
+      - name: Publish to npm
+        run: npm publish --access public

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,16 +18,17 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org/'
 
       - name: Install dependencies
@@ -58,5 +59,3 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Migrates npm publishing from a long-lived NPM_TOKEN to GitHub Actions OIDC. Adds a recovery workflow for publishing an already-tagged release, needed to publish v1.4.1 without bumping the version again.