### PR TITLE
ci: fix recovery release version check

### DIFF
--- a/.github/workflows/publish-existing.yml
+++ b/.github/workflows/publish-existing.yml
@@ -36,7 +36,7 @@ jobs:
         run: npm run build
 
       - name: Verify package version
-        run: test "$(node -p \"require('./package.json').version\")" = "${{ inputs.version }}"
+        run: test "$(node -p 'require(\"./package.json\").version')" = "${{ inputs.version }}"
 
       - name: Publish to npm
         run: npm publish --access public


### PR DESCRIPTION
Fixes shell quoting in the recovery workflow before retrying the v1.4.1 npm publication.