### PR TITLE
ci: repair recovery version validation

### DIFF
--- a/.github/workflows/publish-existing.yml
+++ b/.github/workflows/publish-existing.yml
@@ -36,7 +36,9 @@ jobs:
         run: npm run build
 
       - name: Verify package version
-        run: test "$(node -p 'require(\"./package.json\").version')" = "${{ inputs.version }}"
+        env:
+          EXPECTED_VERSION: ${{ inputs.version }}
+        run: node -e "if (require('./package.json').version !== process.env.EXPECTED_VERSION) process.exit(1)"
 
       - name: Publish to npm
         run: npm publish --access public


### PR DESCRIPTION
Uses a safe environment-variable-based version check in the recovery publishing workflow before retrying v1.4.1.