### PR TITLE
ci: force npm publishing through OIDC

### DIFF
--- a/.github/workflows/publish-existing.yml
+++ b/.github/workflows/publish-existing.yml
@@ -24,7 +24,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '24.x'
-          registry-url: 'https://registry.npmjs.org/'
 
       - name: Install dependencies
         run: npm ci
@@ -41,4 +40,4 @@ jobs:
         run: node -e "if (require('./package.json').version !== process.env.EXPECTED_VERSION) process.exit(1)"
 
       - name: Publish to npm
-        run: npm publish --access public
+        run: unset NODE_AUTH_TOKEN; npm publish --access public

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '24.x'
-          registry-url: 'https://registry.npmjs.org/'
 
       - name: Install dependencies
         run: npm ci
@@ -58,4 +57,4 @@ jobs:
           generate_release_notes: true
 
       - name: Publish to npm
-        run: npm publish --access public
+        run: unset NODE_AUTH_TOKEN; npm publish --access public


### PR DESCRIPTION
Avoids setup-node auth configuration and unsets the inherited NODE_AUTH_TOKEN before npm publish, so npm uses the configured GitHub OIDC trusted publisher.